### PR TITLE
Update ApiDefinitions.cs

### DIFF
--- a/Xamarin.Google.iOS.Maps.Utility/Generated/ApiDefinitions.cs
+++ b/Xamarin.Google.iOS.Maps.Utility/Generated/ApiDefinitions.cs
@@ -393,6 +393,11 @@ interface GMUGeometry
 	[Abstract]
 	[Export ("type")]
 	string Type { get; }
+	
+	// @required @property (readonly, nonatomic) NSString * _Nonnull type;
+	[Abstract]
+	[Export ("coordinates")]
+	GMUCoordinates[] Coordinates { get; }
 }
 
 // @interface GMUStyle : NSObject
@@ -458,8 +463,27 @@ interface GMUGeometryContainer
 	[Export ("geometry")]
 	GMUGeometry Geometry { get; }
 
+	// @required @property (readonly, nonatomic) NSString * _Nonnull type;
+	[Abstract]
+	[Export ("properties")]
+	GMUProperties[] properties { get; }
+	
 	// @required @property (nonatomic) GMUStyle * _Nullable style;
 	[Abstract]
 	[NullAllowed, Export ("style", ArgumentSemantic.Assign)]
 	GMUStyle Style { get; set; }
+}
+
+// @protocol GMUGeometryContainer <NSObject>
+[Protocol, Model]
+[BaseType (typeof(NSObject))]
+interface GMUProperties
+{
+	// @property (readonly, nonatomic) NSString * _Nonnull styleID;
+	[Export ("key")]
+	string key { get; }
+	
+	// @property (readonly, nonatomic) NSString * _Nonnull styleID;
+	[Export ("value")]
+	string value { get; }
 }


### PR DESCRIPTION
Hi,
It seems the GMUGeometryContainer class missing properties values which in standars GeoJson files.
Is it possible to Update the GMUGeometryContainer related Feature data with Properties and coordinates?
 
I tried to add these values to the ApiDefinition to suites the following example json object,
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          5.5718677412470944,
          50.44299705427465
        ]
      },
      "properties": {
        "Id": "999",
        "Street": "Molaanstraat",
      }
    }

I haven't test these changes, Please help.
Thanks.